### PR TITLE
[PATCH] Add support for handling multiple Java options in HiveProcessBuilder

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/hive/HiveProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/hive/HiveProcessBuilder.scala
@@ -62,9 +62,7 @@ class HiveProcessBuilder(
     val memory = conf.get(ENGINE_HIVE_MEMORY)
     buffer += s"-Xmx$memory"
     val javaOptions = conf.get(ENGINE_HIVE_JAVA_OPTIONS)
-    if (javaOptions.isDefined) {
-      buffer += javaOptions.get
-    }
+    javaOptions.map(_.trim.split("\\s+")).foreach(buffer ++= _)
     // -Xmx5g
     // java options
     val classpathEntries = new mutable.LinkedHashSet[String]


### PR DESCRIPTION
Updated HiveProcessBuilder.scala to properly parse and handle multiple Java options specified in ENGINE_HIVE_JAVA_OPTIONS. Instead of appending the options as a single string, they are now split and added individually to the buffer, ensuring proper handling of whitespace-separated JVM arguments.
