### PR TITLE
[ADH-5436] Add OpenMetadata lineage logger

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -336,6 +336,14 @@
             <artifactId>${delta.artifact}_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.kyuubi</groupId>
+            <artifactId>kyuubi-util-scala_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/spark/kyuubi-spark-lineage/pom.xml
+++ b/extensions/spark/kyuubi-spark-lineage/pom.xml
@@ -141,6 +141,36 @@
         </dependency>
 
         <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-core</artifactId>
+            <version>${feign.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-jackson</artifactId>
+            <version>${feign.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-slf4j</artifactId>
+            <version>${feign.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-okhttp</artifactId>
+            <version>${feign.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.kyuubi</groupId>
             <artifactId>kyuubi-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/LineageDispatcher.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/LineageDispatcher.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.execution.QueryExecution
 
 import org.apache.kyuubi.plugin.lineage.dispatcher.{KyuubiEventDispatcher, SparkEventDispatcher}
 import org.apache.kyuubi.plugin.lineage.dispatcher.atlas.AtlasLineageDispatcher
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.OpenMetadataLineageDispatcher
 
 trait LineageDispatcher {
 
@@ -37,6 +38,7 @@ object LineageDispatcher {
       case LineageDispatcherType.SPARK_EVENT => new SparkEventDispatcher()
       case LineageDispatcherType.KYUUBI_EVENT => new KyuubiEventDispatcher()
       case LineageDispatcherType.ATLAS => new AtlasLineageDispatcher()
+      case LineageDispatcherType.OPEN_METADATA => OpenMetadataLineageDispatcher()
       case _ => throw new UnsupportedOperationException(
           s"Unsupported lineage dispatcher: $dispatcherType.")
     }

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataConfig.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataConfig.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata
+
+import org.apache.spark.kyuubi.lineage.OpenMetadataSparkConf.{OPEN_METADATA_DATABASE_SERVICE_NAMES, OPEN_METADATA_JWT, OPEN_METADATA_PIPELINE_SERVICE_NAME, OPEN_METADATA_SERVER_ADDRESS}
+import org.apache.spark.kyuubi.lineage.SparkContextHelper
+
+case class OpenMetadataConfig(
+    serverAddress: String,
+    pipelineServiceName: String,
+    databaseServiceNames: Seq[String] = Seq(),
+    jwt: String)
+
+object OpenMetadataConfig {
+  def apply(): OpenMetadataConfig = {
+    OpenMetadataConfig(
+      SparkContextHelper.getConf(OPEN_METADATA_SERVER_ADDRESS).getOrElse {
+        throw new IllegalArgumentException(
+          s"${OPEN_METADATA_SERVER_ADDRESS.key} option shouldn't be empty")
+      },
+      SparkContextHelper.getConf(OPEN_METADATA_PIPELINE_SERVICE_NAME),
+      SparkContextHelper.getConf(OPEN_METADATA_DATABASE_SERVICE_NAMES),
+      SparkContextHelper.getConf(OPEN_METADATA_JWT).orNull)
+  }
+}

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataConfig.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataConfig.scala
@@ -17,12 +17,13 @@
 
 package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata
 
-import org.apache.spark.kyuubi.lineage.OpenMetadataSparkConf.{OPEN_METADATA_DATABASE_SERVICE_NAMES, OPEN_METADATA_JWT, OPEN_METADATA_PIPELINE_SERVICE_NAME, OPEN_METADATA_SERVER_ADDRESS}
+import org.apache.spark.kyuubi.lineage.OpenMetadataSparkConf.{OPEN_METADATA_DATABASE_SERVICE_NAMES, OPEN_METADATA_JWT, OPEN_METADATA_PIPELINE_NAME, OPEN_METADATA_PIPELINE_SERVICE_NAME, OPEN_METADATA_SERVER_ADDRESS}
 import org.apache.spark.kyuubi.lineage.SparkContextHelper
 
 case class OpenMetadataConfig(
     serverAddress: String,
     pipelineServiceName: String,
+    pipelineName: String,
     databaseServiceNames: Seq[String] = Seq(),
     jwt: String)
 
@@ -34,6 +35,7 @@ object OpenMetadataConfig {
           s"${OPEN_METADATA_SERVER_ADDRESS.key} option shouldn't be empty")
       },
       SparkContextHelper.getConf(OPEN_METADATA_PIPELINE_SERVICE_NAME),
+      SparkContextHelper.getConf(OPEN_METADATA_PIPELINE_NAME),
       SparkContextHelper.getConf(OPEN_METADATA_DATABASE_SERVICE_NAMES),
       SparkContextHelper.getConf(OPEN_METADATA_JWT).orNull)
   }

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataLineageDispatcher.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataLineageDispatcher.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.QueryExecution
+
+import org.apache.kyuubi.plugin.lineage.{Lineage, LineageDispatcher}
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client.RestOpenMetadataClient
+
+class OpenMetadataLineageDispatcher(
+    private val lineageLogger: OpenMetadataLineageLogger) extends LineageDispatcher with Logging {
+
+  override def send(qe: QueryExecution, lineageOpt: Option[Lineage]): Unit = {
+    try {
+      lineageOpt
+        .filter(l => l.inputTables.nonEmpty && l.outputTables.nonEmpty)
+        .foreach(lineageLogger.log(qe, _))
+    } catch {
+      case t: Throwable => logWarning("OpenMetadata lineage logging failed.", t)
+    }
+  }
+
+  override def onFailure(qe: QueryExecution, exception: Exception): Unit = {
+    // ignore
+  }
+
+}
+
+object OpenMetadataLineageDispatcher {
+
+  def apply(): OpenMetadataLineageDispatcher = {
+    val conf = OpenMetadataConfig()
+    val lineageLogger = new OpenMetadataLineageLogger(
+      RestOpenMetadataClient(conf.serverAddress, conf.jwt),
+      conf.databaseServiceNames,
+      conf.pipelineServiceName)
+    new OpenMetadataLineageDispatcher(lineageLogger)
+  }
+}

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataLineageDispatcher.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataLineageDispatcher.scala
@@ -49,7 +49,8 @@ object OpenMetadataLineageDispatcher {
     val lineageLogger = new OpenMetadataLineageLogger(
       RestOpenMetadataClient(conf.serverAddress, conf.jwt),
       conf.databaseServiceNames,
-      conf.pipelineServiceName)
+      conf.pipelineServiceName,
+      conf.pipelineName)
     new OpenMetadataLineageDispatcher(lineageLogger)
   }
 }

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataLineageLogger.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataLineageLogger.scala
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata
+
+import org.apache.spark.sql.execution.QueryExecution
+
+import org.apache.kyuubi.plugin.lineage.{ColumnLineage, Lineage}
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client.OpenMetadataClient
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model.{EntityColumnLineage, LineageDetails, OpenMetadataEntity}
+
+class OpenMetadataLineageLogger(
+    val openMetadataClient: OpenMetadataClient,
+    val databaseServiceNames: Seq[String],
+    pipelineServiceName: String) {
+
+  private lazy val pipelineService = openMetadataClient
+    .createPipelineServiceIfNotExists(pipelineServiceName)
+
+  def log(execution: QueryExecution, lineage: Lineage): Unit = {
+    val inputTablesEntities = getTableNameToEntityMapping(lineage.inputTables)
+    val outputTableEntities = getTableNameToEntityMapping(lineage.outputTables)
+
+    val pipeline = openMetadataClient.createPipelineIfNotExists(
+      pipelineService.fullyQualifiedName,
+      getPipelineName(execution))
+
+    val entityColumnLineage = buildEntityColumnsLineage(
+      inputTablesEntities,
+      outputTableEntities,
+      lineage.columnLineage)
+
+    for (fromTable <- inputTablesEntities.values;
+      toTable <- outputTableEntities.values) {
+      val lineageDetails = LineageDetails(
+        pipeline = pipeline.toReference,
+        description = formatAsCode(execution.sparkPlan.toString()),
+        sqlQuery = execution.logical.origin.sqlText.orNull,
+        columnsLineage = getEntityColumnsLineage(fromTable, toTable, entityColumnLineage))
+
+      openMetadataClient.addLineage(fromTable, toTable, lineageDetails)
+    }
+  }
+
+  private def getEntityColumnsLineage(
+      inputTable: OpenMetadataEntity,
+      outputTable: OpenMetadataEntity,
+      outputTableToColumnsLineage: Map[String, Seq[EntityColumnLineage]])
+      : Seq[EntityColumnLineage] = {
+    outputTableToColumnsLineage.get(outputTable.fullyQualifiedName)
+      .map { columnsLineage =>
+        columnsLineage.map(toInputTableColumnLineage(inputTable, _))
+          .filter(_.isDefined)
+          .map(_.get)
+      }.getOrElse {
+        throw new IllegalArgumentException(
+          s"Malformed lineages map: $outputTableToColumnsLineage. " +
+            s"Key for table ${inputTable.fullyQualifiedName} not found.")
+      }
+  }
+
+  private def toInputTableColumnLineage(
+      inputTable: OpenMetadataEntity,
+      columnLineage: EntityColumnLineage): Option[EntityColumnLineage] = {
+    val inputTableColumnsLineage = columnLineage.fromColumns
+      .filter(inputTable.fullyQualifiedName == extractTableName(_))
+
+    if (inputTableColumnsLineage.isEmpty) {
+      None
+    } else {
+      Some(EntityColumnLineage(
+        columnLineage.toColumn,
+        inputTableColumnsLineage))
+    }
+  }
+
+  private def buildEntityColumnsLineage(
+      inputEntities: Map[String, OpenMetadataEntity],
+      outputEntities: Map[String, OpenMetadataEntity],
+      columnLineage: List[ColumnLineage]): Map[String, Seq[EntityColumnLineage]] = {
+    columnLineage.map {
+      buildEntityColumnLineage(inputEntities, outputEntities, _)
+    }.groupBy { lineage => extractTableName(lineage.toColumn) }
+  }
+
+  private def buildEntityColumnLineage(
+      inputEntities: Map[String, OpenMetadataEntity],
+      outputEntities: Map[String, OpenMetadataEntity],
+      lineage: ColumnLineage): EntityColumnLineage = {
+    val outputEntityColumn = mapColumnName(lineage.column, outputEntities)
+    val inputEntityColumns = lineage.originalColumns
+      .map(mapColumnName(_, inputEntities))
+      .toSeq
+
+    EntityColumnLineage(outputEntityColumn, inputEntityColumns)
+  }
+
+  private def mapColumnName(
+      fullColumnName: String,
+      entityMappings: Map[String, OpenMetadataEntity]): String = {
+    val (fullTableName, columnName) = splitColumnName(fullColumnName)
+
+    entityMappings.get(fullTableName)
+      .map(_.fullyQualifiedName)
+      .map { fqn => s"$fqn.$columnName" }
+      .getOrElse {
+        throw new IllegalArgumentException(s"Malformed entities map $entityMappings." +
+          s"Spark table with name $fullTableName not found")
+      }
+  }
+
+  private def getTableNameToEntityMapping(
+      sparkTableNames: List[String]): Map[String, OpenMetadataEntity] = {
+    sparkTableNames.map {
+      table => (table, getTableEntity(table))
+    }.toMap
+  }
+
+  private def getTableEntity(tableName: String): OpenMetadataEntity = {
+    val maybeTableEntity = if (databaseServiceNames.isEmpty) {
+      searchTableEntityGlobally(tableName)
+    } else {
+      searchTableEntityInServices(tableName)
+    }
+
+    maybeTableEntity.getOrElse {
+      throw new IllegalArgumentException(
+        s"OpenMetadata Entity for table $tableName not found")
+    }
+  }
+
+  private def searchTableEntityGlobally(tableName: String): Option[OpenMetadataEntity] = {
+    val searchPattern = getTableEntityPattern(tableName)
+    openMetadataClient.getTableEntity(searchPattern)
+  }
+
+  private def searchTableEntityInServices(tableName: String): Option[OpenMetadataEntity] = {
+    databaseServiceNames
+      .view
+      .map { dbService =>
+        val searchPattern = getTableEntityPattern(tableName, dbService)
+        openMetadataClient.getTableEntity(searchPattern)
+      }
+      .find(_.isDefined)
+      .flatten
+  }
+
+  private def getTableEntityPattern(tableName: String, prefixes: String*): String = {
+    val tablePattern = tableName.split('.') match {
+      case Array(_, db, table) =>
+        s"*$db.$table"
+      case _ =>
+        throw new IllegalArgumentException("Unsupported table name format")
+    }
+
+    if (prefixes.isEmpty) {
+      tablePattern
+    } else {
+      s"${prefixes.mkString(".")}.$tablePattern"
+    }
+  }
+
+  private def getPipelineName(execution: QueryExecution): String = {
+    val context = execution.sparkSession.sparkContext
+    s"${context.appName}_${context.sparkUser}"
+  }
+
+  private def splitColumnName(fullColumnName: String): (String, String) = {
+    fullColumnName.lastIndexOf('.') match {
+      case -1 => throw new IllegalArgumentException(
+          s"Wrong format of Spark column full name: $fullColumnName")
+      case idx => (fullColumnName.substring(0, idx), fullColumnName.substring(idx + 1))
+    }
+  }
+
+  private def extractTableName(fullColumnName: String): String =
+    splitColumnName(fullColumnName)._1
+
+  private def formatAsCode(rawText: String): String =
+    s"<pre><code>$rawText</code></pre>"
+}

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataLineageLogger.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/OpenMetadataLineageLogger.scala
@@ -26,7 +26,8 @@ import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model.{EntityCol
 class OpenMetadataLineageLogger(
     val openMetadataClient: OpenMetadataClient,
     val databaseServiceNames: Seq[String],
-    pipelineServiceName: String) {
+    pipelineServiceName: String,
+    val pipelineName: String = null) {
 
   private lazy val pipelineService = openMetadataClient
     .createPipelineServiceIfNotExists(pipelineServiceName)
@@ -175,8 +176,12 @@ class OpenMetadataLineageLogger(
   }
 
   private def getPipelineName(execution: QueryExecution): String = {
-    val context = execution.sparkSession.sparkContext
-    s"${context.appName}_${context.sparkUser}"
+    pipelineName match {
+      case null =>
+        val context = execution.sparkSession.sparkContext
+        s"${context.appName}_${context.sparkUser}"
+      case name => name
+    }
   }
 
   private def splitColumnName(fullColumnName: String): (String, String) = {

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/AuthenticationTokenProvider.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/AuthenticationTokenProvider.scala
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.plugin.lineage
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client
 
-object LineageDispatcherType extends Enumeration {
-  type LineageDispatcherType = Value
+trait AuthenticationTokenProvider {
+  def provide(): Option[String]
+}
 
-  val SPARK_EVENT, KYUUBI_EVENT, ATLAS, OPEN_METADATA = Value
+object NoOpAuthenticationTokenProvider extends AuthenticationTokenProvider {
+  override def provide(): Option[String] = None
 }

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/BearerAuthInterceptor.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/BearerAuthInterceptor.scala
@@ -15,10 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.plugin.lineage
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client
 
-object LineageDispatcherType extends Enumeration {
-  type LineageDispatcherType = Value
+import feign.{RequestInterceptor, RequestTemplate}
 
-  val SPARK_EVENT, KYUUBI_EVENT, ATLAS, OPEN_METADATA = Value
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client.BearerAuthInterceptor.{AUTH_HEADER, BEARER_PREFIX}
+
+class BearerAuthInterceptor(
+    val tokenProvider: AuthenticationTokenProvider) extends RequestInterceptor {
+  override def apply(requestTemplate: RequestTemplate): Unit = {
+    if (requestTemplate.headers.containsKey(AUTH_HEADER)) {
+      return
+    }
+
+    tokenProvider.provide()
+      .foreach { token =>
+        requestTemplate.header(AUTH_HEADER, s"$BEARER_PREFIX $token")
+      }
+  }
+}
+
+object BearerAuthInterceptor {
+  val AUTH_HEADER = "Authorization"
+  val BEARER_PREFIX = "Bearer"
 }

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/OpenMetadataApi.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/OpenMetadataApi.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client
+
+import feign.{Headers, Param, RequestLine}
+
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model._
+
+trait OpenMetadataApi {
+
+  @RequestLine(
+    "GET /api/v1/search/fieldQuery?fieldName={fieldName}&fieldValue={fieldValue}&index={index}")
+  @Headers(Array("Accept: application/json"))
+  def searchEntitiesWithSpecificFieldAndValue(
+      @Param("fieldName") fieldName: String,
+      @Param("fieldValue") fieldValue: String,
+      @Param("index") index: String): OpenMetadataEntitySearchResponse
+
+  @RequestLine("PUT /api/v1/pipelines")
+  @Headers(Array("Content-Type: application/json", "Accept: application/json"))
+  def createOrUpdatePipeline(createPipeline: CreatePipelineRequest): OpenMetadataEntityInfo
+
+  @RequestLine("PUT /api/v1/services/pipelineServices")
+  @Headers(Array("Content-Type: application/json", "Accept: application/json"))
+  def createOrUpdatePipelineService(
+      createPipelineService: CreatePipelineServiceRequest): OpenMetadataEntityInfo
+
+  @RequestLine("PUT /api/v1/lineage")
+  @Headers(Array("Content-Type: application/json", "Accept: application/json"))
+  def addLineageEdge(addLineage: AddLineageRequest): Unit
+}

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/OpenMetadataApiBuilder.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/OpenMetadataApiBuilder.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import feign.Feign
+import feign.jackson.{JacksonDecoder, JacksonEncoder}
+import feign.okhttp.OkHttpClient
+import feign.slf4j.Slf4jLogger
+
+trait OpenMetadataApiBuilder {
+  def build(): OpenMetadataApi
+}
+
+class DefaultOpenMetadataApiBuilder(
+    val serverAddress: String,
+    authTokenProvider: AuthenticationTokenProvider) extends OpenMetadataApiBuilder {
+
+  private lazy val objectMapper = new ObjectMapper()
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .disable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
+    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    .registerModule(DefaultScalaModule)
+    .registerModule(new JavaTimeModule)
+    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+
+  private lazy val feignBuilder: Feign.Builder = Feign.builder
+    .encoder(new JacksonEncoder(objectMapper))
+    .decoder(new JacksonDecoder(objectMapper))
+    .requestInterceptor(new BearerAuthInterceptor(authTokenProvider))
+    .logger(new Slf4jLogger)
+    .client(new OkHttpClient)
+
+  override def build(): OpenMetadataApi = {
+    feignBuilder.target(classOf[OpenMetadataApi], serverAddress)
+  }
+}

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/OpenMetadataClient.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/OpenMetadataClient.scala
@@ -15,10 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.plugin.lineage
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client
 
-object LineageDispatcherType extends Enumeration {
-  type LineageDispatcherType = Value
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model.{LineageDetails, OpenMetadataEntity}
 
-  val SPARK_EVENT, KYUUBI_EVENT, ATLAS, OPEN_METADATA = Value
+trait OpenMetadataClient {
+  def createPipelineServiceIfNotExists(pipelineService: String): OpenMetadataEntity
+
+  def createPipelineIfNotExists(
+      pipelineService: String,
+      pipeline: String): OpenMetadataEntity
+
+  def getTableEntity(fullyQualifiedNameTemplate: String): Option[OpenMetadataEntity]
+
+  def addLineage(
+      from: OpenMetadataEntity,
+      to: OpenMetadataEntity,
+      lineageDetails: LineageDetails): Unit
 }

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/RestOpenMetadataClient.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/RestOpenMetadataClient.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client
+
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client.RestOpenMetadataClient._
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model._
+
+class RestOpenMetadataClient(apiBuilder: OpenMetadataApiBuilder) extends OpenMetadataClient {
+
+  private lazy val openMetadataApi: OpenMetadataApi = apiBuilder.build()
+
+  override def getTableEntity(fullyQualifiedNameTemplate: String): Option[OpenMetadataEntity] = {
+    val searchResult = openMetadataApi.searchEntitiesWithSpecificFieldAndValue(
+      TABLE_ENTITY_FQN_FIELD,
+      fullyQualifiedNameTemplate,
+      TABLE_ENTITY_SEARCH_INDEX)
+
+    searchResult.hits.hits
+      .headOption
+      .map(_.entity)
+  }
+
+  override def addLineage(
+      from: OpenMetadataEntity,
+      to: OpenMetadataEntity,
+      lineageDetails: LineageDetails): Unit = {
+    val request = AddLineageRequest(
+      LineageEdge(
+        fromEntity = from.toReference,
+        toEntity = to.toReference,
+        lineageDetails = lineageDetails))
+    openMetadataApi.addLineageEdge(request)
+  }
+
+  override def createPipelineServiceIfNotExists(pipelineService: String): OpenMetadataEntity = {
+    val createPipelineRequest = CreatePipelineServiceRequest(
+      name = pipelineService,
+      serviceType = PIPELINE_SERVICE_TYPE)
+    openMetadataApi.createOrUpdatePipelineService(createPipelineRequest)
+      .withType(PIPELINE_SERVICE_ENTITY_TYPE)
+  }
+
+  override def createPipelineIfNotExists(
+      pipelineService: String,
+      pipeline: String): OpenMetadataEntity = {
+    val createPipelineRequest = CreatePipelineRequest(
+      service = pipelineService,
+      name = pipeline)
+
+    openMetadataApi.createOrUpdatePipeline(createPipelineRequest)
+      .withType(PIPELINE_ENTITY_TYPE)
+  }
+}
+
+object RestOpenMetadataClient {
+  private val TABLE_ENTITY_FQN_FIELD = "fullyQualifiedName"
+  private val TABLE_ENTITY_SEARCH_INDEX = "table_search_index"
+
+  private val PIPELINE_ENTITY_TYPE = "pipeline"
+  private val PIPELINE_SERVICE_ENTITY_TYPE = "pipelineService"
+  private val PIPELINE_SERVICE_TYPE = "Spark"
+
+  def apply(serverAddress: String, jwt: String): RestOpenMetadataClient = {
+    val authTokenProvider = jwt match {
+      case null => NoOpAuthenticationTokenProvider
+      case token => new StaticAuthenticationTokenProvider(token)
+    }
+
+    new RestOpenMetadataClient(
+      new DefaultOpenMetadataApiBuilder(serverAddress, authTokenProvider))
+  }
+}

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/StaticAuthenticationTokenProvider.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/client/StaticAuthenticationTokenProvider.scala
@@ -15,10 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.plugin.lineage
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client
 
-object LineageDispatcherType extends Enumeration {
-  type LineageDispatcherType = Value
-
-  val SPARK_EVENT, KYUUBI_EVENT, ATLAS, OPEN_METADATA = Value
+class StaticAuthenticationTokenProvider(val token: String) extends AuthenticationTokenProvider {
+  def provide(): Option[String] = Some(token)
 }

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/AddLineageRequest.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/AddLineageRequest.scala
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.plugin.lineage
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model
 
-object LineageDispatcherType extends Enumeration {
-  type LineageDispatcherType = Value
+case class AddLineageRequest(edge: LineageEdge)
 
-  val SPARK_EVENT, KYUUBI_EVENT, ATLAS, OPEN_METADATA = Value
-}
+case class LineageEdge(
+    fromEntity: OpenMetadataEntityReference,
+    toEntity: OpenMetadataEntityReference,
+    lineageDetails: LineageDetails)

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/CreatePipelineRequest.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/CreatePipelineRequest.scala
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.plugin.lineage
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model
 
-object LineageDispatcherType extends Enumeration {
-  type LineageDispatcherType = Value
-
-  val SPARK_EVENT, KYUUBI_EVENT, ATLAS, OPEN_METADATA = Value
-}
+case class CreatePipelineRequest(
+    service: String,
+    name: String,
+    description: String = "")

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/CreatePipelineServiceRequest.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/CreatePipelineServiceRequest.scala
@@ -15,10 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.plugin.lineage
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model
 
-object LineageDispatcherType extends Enumeration {
-  type LineageDispatcherType = Value
-
-  val SPARK_EVENT, KYUUBI_EVENT, ATLAS, OPEN_METADATA = Value
-}
+case class CreatePipelineServiceRequest(
+    name: String,
+    serviceType: String)

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/LineageDetails.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/LineageDetails.scala
@@ -15,10 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.plugin.lineage
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model
 
-object LineageDispatcherType extends Enumeration {
-  type LineageDispatcherType = Value
+case class LineageDetails(
+    pipeline: OpenMetadataEntityReference,
+    description: String,
+    sqlQuery: String,
+    columnsLineage: Seq[EntityColumnLineage],
+    source: String = "SparkLineage")
 
-  val SPARK_EVENT, KYUUBI_EVENT, ATLAS, OPEN_METADATA = Value
-}
+case class EntityColumnLineage(
+    toColumn: String,
+    fromColumns: Seq[String])

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/OpenMetadataEntity.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/OpenMetadataEntity.scala
@@ -15,10 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.plugin.lineage
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model
 
-object LineageDispatcherType extends Enumeration {
-  type LineageDispatcherType = Value
+import java.util.UUID
 
-  val SPARK_EVENT, KYUUBI_EVENT, ATLAS, OPEN_METADATA = Value
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class OpenMetadataEntity(
+    id: UUID,
+    fullyQualifiedName: String,
+    entityType: String) {
+
+  def toReference: OpenMetadataEntityReference =
+    OpenMetadataEntityReference(id, entityType)
 }
+
+case class OpenMetadataEntityInfo(id: UUID, fullyQualifiedName: String) {
+  def withType(entityType: String): OpenMetadataEntity =
+    OpenMetadataEntity(id, fullyQualifiedName, entityType)
+}
+
+case class OpenMetadataEntityReference(
+    id: UUID,
+    @JsonProperty("type")
+    entityType: String)

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/OpenMetadataEntitySearchResponse.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/dispatcher/openmetadata/model/OpenMetadataEntitySearchResponse.scala
@@ -15,10 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.plugin.lineage
+package org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model
 
-object LineageDispatcherType extends Enumeration {
-  type LineageDispatcherType = Value
+import com.fasterxml.jackson.annotation.JsonProperty
 
-  val SPARK_EVENT, KYUUBI_EVENT, ATLAS, OPEN_METADATA = Value
-}
+case class OpenMetadataEntitySearchResponse(hits: OpenMetadataEntitySearchHits)
+
+case class OpenMetadataEntitySearchHits(hits: Seq[OpenMetadataEntitySearchHit])
+
+case class OpenMetadataEntitySearchHit(
+    @JsonProperty("_source")
+    entity: OpenMetadataEntity)

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/spark/kyuubi/lineage/LineageConf.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/spark/kyuubi/lineage/LineageConf.scala
@@ -36,6 +36,7 @@ object LineageConf {
       "`org.apache.kyuubi.plugin.lineage.LineageDispatcher` for dispatching lineage events.<ul>" +
       "<li>SPARK_EVENT: send lineage event to spark event bus</li>" +
       "<li>KYUUBI_EVENT: send lineage event to kyuubi event bus</li>" +
+      "<li>OPEN_METADATA: send lineage to OpenMetadata</li>" +
       "<li>ATLAS: send lineage to apache atlas</li>" +
       "</ul>")
     .version("1.8.0")
@@ -47,5 +48,4 @@ object LineageConf {
     .createWithDefault(Seq(LineageDispatcherType.SPARK_EVENT.toString))
 
   val DEFAULT_CATALOG: String = SQLConf.get.getConf(SQLConf.DEFAULT_CATALOG)
-
 }

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/spark/kyuubi/lineage/OpenMetadataSparkConf.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/spark/kyuubi/lineage/OpenMetadataSparkConf.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.kyuubi.lineage
+
+import org.apache.spark.internal.config.{ConfigBuilder, ConfigEntry, OptionalConfigEntry}
+
+object OpenMetadataSparkConf {
+  val OPEN_METADATA_SERVER_ADDRESS: OptionalConfigEntry[String] =
+    ConfigBuilder("spark.kyuubi.plugin.lineage.openmetadata.server")
+      .doc("Address of the OpenMetadata server")
+      .version("1.9.2")
+      .stringConf
+      .createOptional
+
+  val OPEN_METADATA_JWT: OptionalConfigEntry[String] =
+    ConfigBuilder("spark.kyuubi.plugin.lineage.openmetadata.jwt")
+      .doc("JsonWebToken for authenticating to the OpenMetadata server")
+      .version("1.9.2")
+      .stringConf
+      .createOptional
+
+  val OPEN_METADATA_PIPELINE_SERVICE_NAME: ConfigEntry[String] =
+    ConfigBuilder("spark.kyuubi.plugin.lineage.openmetadata.pipelineServiceName")
+      .doc("The name of the OpenMetadata pipeline service where " +
+        "the spark pipelines will be created. If pipeline service " +
+        "with specified name already exists it will be used, otherwise it will be created.")
+      .version("1.9.2")
+      .stringConf
+      .createWithDefault("SparkOnKyuubi")
+
+  val OPEN_METADATA_DATABASE_SERVICE_NAMES: ConfigEntry[Seq[String]] =
+    ConfigBuilder("spark.kyuubi.plugin.lineage.openmetadata.databaseServiceNames")
+      .doc("The comma separated list of database service names which contains the source tables " +
+        "used in this job. If no services is provided then the search will be conducted " +
+        "through all the database services available in the OpenMetadata server.")
+      .version("1.9.2")
+      .stringConf
+      .toSequence
+      .createWithDefault(Seq())
+}

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/spark/kyuubi/lineage/OpenMetadataSparkConf.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/spark/kyuubi/lineage/OpenMetadataSparkConf.scala
@@ -43,6 +43,14 @@ object OpenMetadataSparkConf {
       .stringConf
       .createWithDefault("SparkOnKyuubi")
 
+  val OPEN_METADATA_PIPELINE_NAME: ConfigEntry[String] =
+    ConfigBuilder("spark.kyuubi.plugin.lineage.openmetadata.pipelineName")
+      .doc("The name of the OpenMetadata pipeline. If pipeline " +
+        "with specified name already exists it will be used, otherwise it will be created.")
+      .version("1.9.2")
+      .stringConf
+      .createWithDefault("SparkOnKyuubi")
+
   val OPEN_METADATA_DATABASE_SERVICE_NAMES: ConfigEntry[Seq[String]] =
     ConfigBuilder("spark.kyuubi.plugin.lineage.openmetadata.databaseServiceNames")
       .doc("The comma separated list of database service names which contains the source tables " +

--- a/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/dispatcher/atlas/OpenMetadataLineageDispatcherSuite.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/dispatcher/atlas/OpenMetadataLineageDispatcherSuite.scala
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.lineage.dispatcher.atlas
+
+import java.util.UUID
+
+import scala.collection.mutable
+
+import org.apache.spark.SparkConf
+import org.apache.spark.kyuubi.lineage.LineageConf.DEFAULT_CATALOG
+import org.apache.spark.sql.SparkListenerExtensionTest
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.execution.QueryExecution
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
+import org.apache.kyuubi.KyuubiFunSuite
+import org.apache.kyuubi.plugin.lineage.Lineage
+import org.apache.kyuubi.plugin.lineage.dispatcher.atlas.OpenMetadataLineageDispatcherSuite.{TEST_PIPELINE_SERVICE_NAME, TEST_SPARK_APP_NAME}
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.OpenMetadataLineageLogger
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.client.OpenMetadataClient
+import org.apache.kyuubi.plugin.lineage.dispatcher.openmetadata.model.{LineageDetails, OpenMetadataEntity}
+import org.apache.kyuubi.plugin.lineage.helper.SparkListenerHelper.SPARK_RUNTIME_VERSION
+
+class OpenMetadataLineageDispatcherSuite extends KyuubiFunSuite with SparkListenerExtensionTest {
+  private val catalogName = if (SPARK_RUNTIME_VERSION <= "3.1") {
+    "org.apache.spark.sql.connector.InMemoryTableCatalog"
+  } else {
+    "org.apache.spark.sql.connector.catalog.InMemoryTableCatalog"
+  }
+
+  override protected val catalogImpl: String = "hive"
+
+  override def sparkConf(): SparkConf = {
+    super.sparkConf()
+      .set("spark.sql.catalog.v2_catalog", catalogName)
+      .set("spark.app.name", TEST_SPARK_APP_NAME)
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.sql("create database if not exists test_db")
+  }
+
+  override def afterAll(): Unit = {
+    spark.sql("drop database if exists test_db")
+    spark.stop()
+    super.afterAll()
+  }
+
+  test("log lineage with no specified db services") {
+    val entitiesMap = Seq("default.test_table0", "default.test_table1")
+      .map { table => ("*" + table, entity(table)) }
+      .toMap
+
+    val openMetadataClient = new MockOpenMetadataClient(entitiesMap)
+    val lineageLogger = new OpenMetadataLineageLogger(
+      openMetadataClient,
+      Seq(),
+      TEST_PIPELINE_SERVICE_NAME)
+
+    withTable("test_table0") { _ =>
+      withTable("test_table1") { _ =>
+        spark.sql("create table test_table0(a string, b int, c int)")
+        spark.sql("create table test_table1(a string, d int)")
+
+        val query = "insert into test_table1 select a, b + c as d from test_table0"
+
+        val lineage = Lineage(
+          List(s"$DEFAULT_CATALOG.default.test_table0"),
+          List(s"$DEFAULT_CATALOG.default.test_table1"),
+          List(
+            (
+              s"$DEFAULT_CATALOG.default.test_table1.a",
+              Set(s"$DEFAULT_CATALOG.default.test_table0.a")),
+            (
+              s"$DEFAULT_CATALOG.default.test_table1.d",
+              Set(
+                s"$DEFAULT_CATALOG.default.test_table0.b",
+                s"$DEFAULT_CATALOG.default.test_table0.c"))))
+
+        val queryExecution = spark.sql(query).queryExecution
+        lineageLogger.log(queryExecution, lineage)
+
+        eventually(Timeout(5.seconds)) {
+          assert(openMetadataClient.lineages.nonEmpty)
+        }
+
+        assertClientRequests(openMetadataClient, lineage, query)
+      }
+    }
+  }
+
+  test("log lineage with specified db services") {
+    val entitiesMap = Map(
+      "dbService1.*test_db.tb1" -> entity("test_db.tb1"),
+      "dbService2.*test_db.tb2" -> entity("test_db.tb2"),
+      "dbService2.*test_db.dest" -> entity("test_db.dest"))
+
+    val openMetadataClient = new MockOpenMetadataClient(entitiesMap)
+    val lineageLogger = new OpenMetadataLineageLogger(
+      openMetadataClient,
+      Seq("otherDbService", "dbService1", "dbService2"),
+      TEST_PIPELINE_SERVICE_NAME)
+
+    withTable("test_db.tb1") { _ =>
+      withTable("test_db.tb2") { _ =>
+        withTable("test_db.dest") { _ =>
+          spark.sql("create table test_db.tb1(col1 string, col2 string, col3 string)")
+          spark.sql("create table test_db.tb2(col1 string, col2 string, col3 string)")
+          spark.sql("create table test_db.dest(a1 string, b1 string, ab1 string, ab2 string)")
+
+          val query =
+            """
+              |insert into test_db.dest
+              |select t1.col1 as a1, t2.col1 as b1, concat(t1.col1, t2.col1) as ab1,
+              |concat(concat(t1.col1, t2.col2), concat(t1.col2, t2.col3)) as ab2
+              |from test_db.tb1 t1 join test_db.tb2 t2
+              |on t1.col1 = t2.col1
+              |""".stripMargin
+
+          val queryExecution = spark.sql(query).queryExecution
+
+          val lineage = Lineage(
+            List(s"$DEFAULT_CATALOG.test_db.tb1", s"$DEFAULT_CATALOG.test_db.tb2"),
+            List(s"$DEFAULT_CATALOG.test_db.dest"),
+            List(
+              (s"$DEFAULT_CATALOG.test_db.dest.a1", Set(s"$DEFAULT_CATALOG.test_db.tb1.col1")),
+              (s"$DEFAULT_CATALOG.test_db.dest.b1", Set(s"$DEFAULT_CATALOG.test_db.tb2.col1")),
+              (
+                s"$DEFAULT_CATALOG.test_db.dest.ab1",
+                Set(s"$DEFAULT_CATALOG.test_db.tb1.col1", s"$DEFAULT_CATALOG.test_db.tb2.col1")),
+              (
+                s"$DEFAULT_CATALOG.test_db.dest.ab2",
+                Set(
+                  s"$DEFAULT_CATALOG.test_db.tb1.col1",
+                  s"$DEFAULT_CATALOG.test_db.tb1.col2",
+                  s"$DEFAULT_CATALOG.test_db.tb2.col2",
+                  s"$DEFAULT_CATALOG.test_db.tb2.col3"))))
+
+          lineageLogger.log(queryExecution, lineage)
+
+          eventually(Timeout(5.seconds)) {
+            assert(openMetadataClient.lineages.size == 2)
+          }
+
+          assertClientRequests(openMetadataClient, lineage, query)
+        }
+      }
+    }
+  }
+
+  test("fail if entity for src table not found with no specified db services") {
+    val tableEntities: Map[String, OpenMetadataEntity] = Map()
+    val databaseServiceNames: Seq[String] = Seq()
+
+    checkFailIfNoTableFound(tableEntities, databaseServiceNames)
+  }
+
+  test("fail if entity for src table not found with specified db services") {
+    val tableEntities: Map[String, OpenMetadataEntity] = Map()
+    val databaseServiceNames: Seq[String] = Seq("dbService1", "dbService2")
+
+    checkFailIfNoTableFound(tableEntities, databaseServiceNames)
+  }
+
+  test("fail if entity for dest table not found with no specified db services") {
+    val tableEntities: Map[String, OpenMetadataEntity] = Map(
+      "*default.dest" -> entity("default.dest"))
+    val databaseServiceNames: Seq[String] = Seq()
+
+    checkFailIfNoTableFound(tableEntities, databaseServiceNames)
+  }
+
+  test("fail if entity for dest table not found with specified db services") {
+    val tableEntities: Map[String, OpenMetadataEntity] = Map(
+      "*default.dest" -> entity("default.dest"))
+    val databaseServiceNames: Seq[String] = Seq("dbService1", "dbService2")
+
+    checkFailIfNoTableFound(tableEntities, databaseServiceNames)
+  }
+
+  private def checkFailIfNoTableFound(
+      tableEntities: Map[String, OpenMetadataEntity],
+      databaseServiceNames: Seq[String]): Unit = {
+    val openMetadataClient = new MockOpenMetadataClient(tableEntities)
+    val lineageLogger = new OpenMetadataLineageLogger(
+      openMetadataClient,
+      databaseServiceNames,
+      TEST_PIPELINE_SERVICE_NAME)
+
+    val execution = new QueryExecution(spark, LocalRelation())
+    val lineage = Lineage(
+      List(s"$DEFAULT_CATALOG.default.src"),
+      List(s"$DEFAULT_CATALOG.default.dest"),
+      List())
+
+    val exception = intercept[IllegalArgumentException] {
+      lineageLogger.log(execution, lineage)
+    }
+    assert(exception.getMessage.contains("not found"))
+  }
+
+  private def assertClientRequests(
+      client: MockOpenMetadataClient,
+      lineage: Lineage,
+      query: String): Unit = {
+    assert(client.pipelineServices.size == 1)
+    assert(client.pipelineServices.contains(TEST_PIPELINE_SERVICE_NAME))
+
+    assert(client.pipelines.size == 1)
+    assert(client.pipelines.keys.exists(_.startsWith(TEST_SPARK_APP_NAME)))
+
+    assert(client.lineages.nonEmpty)
+    assertLineage(client, lineage, query)
+  }
+
+  private def assertLineage(
+      client: MockOpenMetadataClient,
+      lineage: Lineage,
+      query: String): Unit = {
+    for (src <- lineage.inputTables;
+      dest <- lineage.outputTables) {
+      val lineageEdge = client.lineages.get(
+        LineageKey(removeCatalog(src), removeCatalog(dest)))
+      assert(lineageEdge.isDefined)
+      assert(lineageEdge.get.sqlQuery == query)
+
+      val columnLineages = lineage.columnLineage
+        .filter(_.column.startsWith(dest))
+
+      for (columnLineage <- columnLineages) {
+        val actualSrcColumns = lineageEdge.get.columnsLineage
+          .find(_.toColumn == removeCatalog(columnLineage.column))
+          .map(_.fromColumns)
+          .getOrElse(Seq())
+
+        val expectedSrcColumns = columnLineage.originalColumns
+          .filter(_.startsWith(src))
+          .map(removeCatalog)
+
+        assert(expectedSrcColumns == actualSrcColumns.toSet)
+      }
+    }
+  }
+
+  private def removeCatalog(tableName: String): String = {
+    tableName.replace(s"$DEFAULT_CATALOG.", "")
+  }
+
+  private def entity(name: String, entityType: String = "table") =
+    OpenMetadataEntity(UUID.randomUUID(), name, entityType)
+
+  class MockOpenMetadataClient(tableEntities: Map[String, OpenMetadataEntity])
+    extends OpenMetadataClient {
+    val pipelineServices: mutable.Map[String, OpenMetadataEntity] = mutable.Map()
+    val pipelines: mutable.Map[String, OpenMetadataEntity] = mutable.Map()
+    val lineages: mutable.Map[LineageKey, LineageDetails] = mutable.Map()
+
+    override def createPipelineServiceIfNotExists(pipelineService: String): OpenMetadataEntity = {
+      pipelineServices.getOrElseUpdate(
+        pipelineService,
+        entity(pipelineService, "pipelineService"))
+    }
+
+    override def createPipelineIfNotExists(
+        pipelineService: String,
+        pipeline: String): OpenMetadataEntity = {
+
+      pipelines.getOrElseUpdate(
+        pipeline,
+        entity(pipeline, "pipeline"))
+    }
+
+    override def getTableEntity(fullyQualifiedNameTemplate: String): Option[OpenMetadataEntity] = {
+      tableEntities.get(fullyQualifiedNameTemplate)
+    }
+
+    override def addLineage(
+        from: OpenMetadataEntity,
+        to: OpenMetadataEntity,
+        lineageDetails: LineageDetails): Unit = {
+      lineages(LineageKey(from.fullyQualifiedName, to.fullyQualifiedName)) = lineageDetails
+    }
+  }
+
+  case class LineageKey(from: String, to: String)
+}
+
+object OpenMetadataLineageDispatcherSuite {
+  val TEST_SPARK_APP_NAME = "open_metadata_test_app"
+  val TEST_PIPELINE_SERVICE_NAME = "testSparkLineage"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,7 @@
         <scopt.version>4.1.0</scopt.version>
         <slf4j.version>1.7.36</slf4j.version>
         <snakeyaml.version>2.2</snakeyaml.version>
+        <feign.version>13.5</feign.version>
         <!--
           DO NOT forget to change the following properties when change the minor version of Spark:
           `delta.version`, `delta.artifact`, `maven.plugin.scalatest.exclude.tags`


### PR DESCRIPTION
- Added `OpenMetadataLineageDispatcher` for sending lineage events to OpenMetadata server
- Added new possible value `OPEN_METADATA` for the `spark.kyuubi.plugin.lineage.dispatchers` option
