### PR TITLE
fix(trino): add Kerberos authentication support

### DIFF
--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/session/TrinoSessionImpl.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/session/TrinoSessionImpl.scala
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.engine.trino.session
 
+import java.io.File
 import java.net.URI
 import java.time.ZoneId
 import java.util.{Locale, Optional}
@@ -157,15 +158,20 @@ class TrinoSessionImpl(
       val delegatedKerberos = sessionConf
         .get(KyuubiConf.ENGINE_TRINO_CONNECTION_KERBEROS_DELEGATED_KERBEROS)
 
+      val configFile = kerberosConfig.map(new File(_))
+      val keytabFile = keytab.map(new File(_))
+      val credCacheFile = credentialCache.map(new File(_))
+
+
       OkHttpUtil.setupKerberos(
         builder,
         servicePrincipalPattern,
         remoteServiceName,
         useCanonicalHostname,
-        Optional.ofNullable(principal),
-        Optional.ofNullable(kerberosConfig),
-        Optional.ofNullable(keytab),
-        Optional.ofNullable(credentialCache),
+        Optional.ofNullable(principal.orNull),
+        Optional.ofNullable(configFile.orNull),
+        Optional.ofNullable(keytabFile.orNull),
+        Optional.ofNullable(credCacheFile.orNull),
         delegatedKerberos)
     }
 

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/session/TrinoSessionImpl.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/session/TrinoSessionImpl.scala
@@ -162,7 +162,6 @@ class TrinoSessionImpl(
       val keytabFile = keytab.map(new File(_))
       val credCacheFile = credentialCache.map(new File(_))
 
-
       OkHttpUtil.setupKerberos(
         builder,
         servicePrincipalPattern,

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/session/TrinoSessionImpl.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/session/TrinoSessionImpl.scala
@@ -136,6 +136,39 @@ class TrinoSessionImpl(
         Optional.ofNullable(truststoreType.orNull),
         true)
     }
+
+    val kerberosEnabled = sessionConf.get(KyuubiConf.ENGINE_TRINO_CONNECTION_KERBEROS_ENABLED)
+
+    if (kerberosEnabled) {
+      val servicePrincipalPattern = sessionConf
+        .get(KyuubiConf.ENGINE_TRINO_CONNECTION_KERBEROS_SERVICE_PRINCIPAL_PATTERN)
+      val remoteServiceName = sessionConf
+        .get(KyuubiConf.ENGINE_TRINO_CONNECTION_KERBEROS_REMOTE_SERVICE_NAME)
+      val useCanonicalHostname = sessionConf
+        .get(KyuubiConf.ENGINE_TRINO_CONNECTION_KERBEROS_USE_CANONICAL_HOSTNAME)
+      val principal = sessionConf
+        .get(KyuubiConf.ENGINE_TRINO_CONNECTION_KERBEROS_PRINCIPAL)
+      val kerberosConfig = sessionConf
+        .get(KyuubiConf.ENGINE_TRINO_CONNECTION_KERBEROS_CONFIG)
+      val keytab = sessionConf
+        .get(KyuubiConf.ENGINE_TRINO_CONNECTION_KERBEROS_KEYTAB)
+      val credentialCache = sessionConf
+        .get(KyuubiConf.ENGINE_TRINO_CONNECTION_KERBEROS_CREDENTIAL_CACHE)
+      val delegatedKerberos = sessionConf
+        .get(KyuubiConf.ENGINE_TRINO_CONNECTION_KERBEROS_DELEGATED_KERBEROS)
+
+      OkHttpUtil.setupKerberos(
+        builder,
+        servicePrincipalPattern,
+        remoteServiceName,
+        useCanonicalHostname,
+        Optional.ofNullable(principal),
+        Optional.ofNullable(kerberosConfig),
+        Optional.ofNullable(keytab),
+        Optional.ofNullable(credentialCache),
+        delegatedKerberos)
+    }
+
     sessionConf.get(KyuubiConf.ENGINE_TRINO_CONNECTION_PASSWORD).foreach { password =>
       require(
         serverScheme.equalsIgnoreCase("https"),

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1585,7 +1585,8 @@ object KyuubiConf {
 
   val ENGINE_TRINO_CONNECTION_KERBEROS_SERVICE_PRINCIPAL_PATTERN: ConfigEntry[String] =
     buildConf("kyuubi.engine.trino.connection.kerberos.servicePrincipalPattern")
-      .doc("Pattern for constructing the Kerberos service principal, using variables ${SERVICE} and ${HOST}")
+      .doc("Pattern for constructing the Kerberos service principal," +
+        " using variables ${SERVICE} and ${HOST}")
       .version("1.10.1")
       .stringConf
       .createWithDefault("${SERVICE}@${HOST}")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1576,6 +1576,69 @@ object KyuubiConf {
       .checkValue(_ >= 200, "Minimum 200 milliseconds")
       .createWithDefault(1000)
 
+  val ENGINE_TRINO_CONNECTION_KERBEROS_ENABLED: ConfigEntry[Boolean] =
+    buildConf("kyuubi.engine.trino.connection.kerberos.enabled")
+      .doc("Enable Kerberos authentication when connecting to Trino")
+      .version("1.10.1")
+      .booleanConf
+      .createWithDefault(false)
+
+  val ENGINE_TRINO_CONNECTION_KERBEROS_SERVICE_PRINCIPAL_PATTERN: ConfigEntry[String] =
+    buildConf("kyuubi.engine.trino.connection.kerberos.servicePrincipalPattern")
+      .doc("Pattern for constructing the Kerberos service principal, using variables ${SERVICE} and ${HOST}")
+      .version("1.10.1")
+      .stringConf
+      .createWithDefault("${SERVICE}@${HOST}")
+
+  val ENGINE_TRINO_CONNECTION_KERBEROS_REMOTE_SERVICE_NAME: ConfigEntry[String] =
+    buildConf("kyuubi.engine.trino.connection.kerberos.remoteServiceName")
+      .doc("Remote service name for Kerberos (typically 'HTTP')")
+      .version("1.10.1")
+      .stringConf
+      .createWithDefault("HTTP")
+
+  val ENGINE_TRINO_CONNECTION_KERBEROS_USE_CANONICAL_HOSTNAME: ConfigEntry[Boolean] =
+    buildConf("kyuubi.engine.trino.connection.kerberos.useCanonicalHostname")
+      .doc("Use the canonical hostname when acquiring the Kerberos ticket")
+      .version("1.10.1")
+      .booleanConf
+      .createWithDefault(true)
+
+  val ENGINE_TRINO_CONNECTION_KERBEROS_PRINCIPAL: OptionalConfigEntry[String] =
+    buildConf("kyuubi.engine.trino.connection.kerberos.principal")
+      .doc("Kerberos principal for authentication (format: primary/instance@REALM)")
+      .version("1.10.1")
+      .stringConf
+      .createOptional
+
+  val ENGINE_TRINO_CONNECTION_KERBEROS_CONFIG: OptionalConfigEntry[String] =
+    buildConf("kyuubi.engine.trino.connection.kerberos.config")
+      .doc("Path to the Kerberos configuration file (krb5.conf)")
+      .version("1.10.1")
+      .stringConf
+      .createOptional
+
+  val ENGINE_TRINO_CONNECTION_KERBEROS_KEYTAB: OptionalConfigEntry[String] =
+    buildConf("kyuubi.engine.trino.connection.kerberos.keytab")
+      .doc("Path to the keytab file containing the Kerberos principal credentials")
+      .version("1.10.1")
+      .stringConf
+      .createOptional
+
+  val ENGINE_TRINO_CONNECTION_KERBEROS_CREDENTIAL_CACHE: OptionalConfigEntry[String] =
+    buildConf("kyuubi.engine.trino.connection.kerberos.credentialCache")
+      .doc("Path to the Kerberos credential cache file")
+      .version("1.10.1")
+      .stringConf
+      .createOptional
+
+  val ENGINE_TRINO_CONNECTION_KERBEROS_DELEGATED_KERBEROS: ConfigEntry[Boolean] =
+    buildConf("kyuubi.engine.trino.connection.kerberos.delegatedKerberos")
+      .doc("Enable Kerberos credential delegation to the Trino server")
+      .version("1.10.1")
+      .booleanConf
+      .createWithDefault(false)
+
   val ENGINE_HIVE_MAIN_RESOURCE: OptionalConfigEntry[String] =
     buildConf("kyuubi.session.engine.hive.main.resource")
       .doc("The package used to create Hive engine remote job. If it is undefined," +


### PR DESCRIPTION
This patch enables Kerberos-secured connections for the Trino engine by:

- Introducing new KyuubiConf entries (v1.10.1) for Kerberos settings: • kyuubi.engine.trino.connection.kerberos.enabled • kyuubi.engine.trino.connection.kerberos.servicePrincipalPattern • kyuubi.engine.trino.connection.kerberos.remoteServiceName • kyuubi.engine.trino.connection.kerberos.useCanonicalHostname • kyuubi.engine.trino.connection.kerberos.principal • kyuubi.engine.trino.connection.kerberos.config • kyuubi.engine.trino.connection.kerberos.keytab • kyuubi.engine.trino.connection.kerberos.credentialCache • kyuubi.engine.trino.connection.kerberos.delegatedKerberos

- Adding logic in TrinoSessionImpl to read these configs and call OkHttpUtil.setupKerberos(...) when enabled.

This allows users to configure Kerberos principal, keytab, credential cache, service name patterns, and credential delegation for Trino connections.


